### PR TITLE
Error handling

### DIFF
--- a/src/controllers/categoryController.ts
+++ b/src/controllers/categoryController.ts
@@ -1,5 +1,6 @@
-import Category from '../models/Category';
 import { Request, Response, NextFunction } from 'express';
+import Category from '../models/Category';
+import { NotFoundError } from '../errors/httpErrors';
 
 async function retrieveCategory(req: Request, res: Response, next: NextFunction) {
   try {
@@ -7,8 +8,7 @@ async function retrieveCategory(req: Request, res: Response, next: NextFunction)
       include: [{ association: Category.associations.CategoryStalls }],
     });
     if (category === null) {
-      res.status(404).end();
-      return;
+      throw new NotFoundError('Category cannot be found');
     }
     req.category = category;
     next();

--- a/src/controllers/categoryStallController.ts
+++ b/src/controllers/categoryStallController.ts
@@ -1,5 +1,6 @@
 import CategoryStall from '../models/CategoryStall';
 import { Request, Response, NextFunction } from 'express';
+import { NotFoundError } from '../errors/httpErrors';
 
 async function retrieveCategoryStall(req: Request, res: Response, next: NextFunction) {
   try {
@@ -10,8 +11,7 @@ async function retrieveCategoryStall(req: Request, res: Response, next: NextFunc
       ],
     });
     if (categoryStall === null) {
-      res.status(404).end();
-      return;
+      throw new NotFoundError('CategoryStall cannot be found');
     }
     req.categoryStall = categoryStall;
     next();

--- a/src/controllers/hawkerCentreController.ts
+++ b/src/controllers/hawkerCentreController.ts
@@ -8,7 +8,7 @@ async function retrieveHawkerCentre(req: Request, res: Response, next: NextFunct
       include: [{ association: HawkerCentre.associations.Stalls }],
     });
     if (hawkerCentre === null) {
-      throw new NotFoundError('Hawker Centre cannot be found');
+      throw new NotFoundError('HawkerCentre cannot be found');
     }
     req.hawkerCentre = hawkerCentre;
     next();

--- a/src/controllers/hawkerCentreController.ts
+++ b/src/controllers/hawkerCentreController.ts
@@ -1,5 +1,6 @@
 import HawkerCentre from '../models/HawkerCentre';
 import { Request, Response, NextFunction } from 'express';
+import { NotFoundError } from '../errors/httpErrors';
 
 async function retrieveHawkerCentre(req: Request, res: Response, next: NextFunction) {
   try {
@@ -7,8 +8,7 @@ async function retrieveHawkerCentre(req: Request, res: Response, next: NextFunct
       include: [{ association: HawkerCentre.associations.Stalls }],
     });
     if (hawkerCentre === null) {
-      res.status(404).end();
-      return;
+      throw new NotFoundError('Hawker Centre cannot be found');
     }
     req.hawkerCentre = hawkerCentre;
     next();

--- a/src/controllers/imageController.ts
+++ b/src/controllers/imageController.ts
@@ -18,20 +18,16 @@ import { GCS_BUCKET, GCS_CLIENT_EMAIL, GCS_PRIVATE_KEY, MAX_IMAGE_SIZE } from '.
  */
 
 function fileFilter(req: Request, file: Express.Multer.File, cb: Function) {
-  console.log('HI');
   const regexp = /png|jpe?g|gif/;
   const result = mime.extension(file.mimetype);
 
-  console.log(result);
 
   if (!result || !regexp.test(result)) {
     // TODO: Could throw an error here too and surface to user
     // return cb(new Error('Invalid mimetype')); // short circuits
 
-    console.log('invalid');
     return cb(null, false); // Only reject the specific file
   } else {
-    console.log('valid');
     cb(null, true);
   }
 }

--- a/src/controllers/productController.ts
+++ b/src/controllers/productController.ts
@@ -2,6 +2,7 @@ import { Request, Response, NextFunction } from 'express';
 import { upload, sendUploadToGCS, createImages } from './imageController';
 import Product from '../models/Product';
 import Stall from '../models/Stall';
+import { NotFoundError } from '../errors/httpErrors';
 
 import { MAX_NUM_IMAGES, UPLOAD_FORM_FIELD } from '../consts';
 
@@ -21,8 +22,7 @@ async function retrieveProduct(req: Request, res: Response, next: NextFunction) 
       include: getProductInclude(),
     });
     if (product === null) {
-      res.status(404).end();
-      return;
+      throw new NotFoundError('Product cannot be found');
     }
     req.product = product;
     next();

--- a/src/controllers/regionController.ts
+++ b/src/controllers/regionController.ts
@@ -1,51 +1,12 @@
 import Region from '../models/Region';
 import { Request, Response, NextFunction } from 'express';
-
-async function postIdFormatting(req: Request, res: Response, next: NextFunction) {
-  try {
-    const region = { id: req.body['regionId'], ...req.body };
-    delete region['regionId'];
-    req.body = region;
-    next();
-  } catch (err) {
-    next(err);
-  }
-}
-
-async function getIdFormatting(req: Request, res: Response, next: NextFunction) {
-  try {
-    let plainRegion = JSON.parse(JSON.stringify(req.region));
-    plainRegion = { regionId: plainRegion['id'], ...plainRegion };
-    delete plainRegion['id'];
-
-    req.body = plainRegion;
-    next();
-  } catch (err) {
-    next(err);
-  }
-}
-
-async function getMultipleIdFormatting(req: Request, res: Response, next: NextFunction) {
-  try {
-    const changedKeys = req.body.map((x: Region) => {
-      let plainRegion = JSON.parse(JSON.stringify(x));
-      plainRegion = { regionId: plainRegion['id'], ...plainRegion };
-      delete plainRegion['id'];
-      return plainRegion;
-    });
-
-    res.status(201).json(changedKeys);
-  } catch (err) {
-    next(err);
-  }
-}
+import { NotFoundError } from '../errors/httpErrors';
 
 async function retrieveRegion(req: Request, res: Response, next: NextFunction) {
   try {
     const region = await Region.findByPk(req.params.id);
     if (region === null) {
-      res.status(404).end();
-      return;
+      throw new NotFoundError('Region cannot be found');
     }
     req.region = region;
     next();
@@ -57,8 +18,7 @@ async function retrieveRegion(req: Request, res: Response, next: NextFunction) {
 async function indexRegion(req: Request, res: Response, next: NextFunction) {
   try {
     const regions = await Region.findAll();
-    req.body = regions;
-    next();
+    res.status(200).json(regions);
   } catch (err) {
     next(err);
   }
@@ -66,7 +26,7 @@ async function indexRegion(req: Request, res: Response, next: NextFunction) {
 
 async function showRegion(req: Request, res: Response, next: NextFunction) {
   try {
-    res.status(200).json(req.body);
+    res.status(200).json(req.region);
   } catch (err) {
     next(err);
   }
@@ -99,8 +59,8 @@ async function destroyRegion(req: Request, res: Response, next: NextFunction) {
   }
 }
 
-export const indexRegionFuncs = [indexRegion, getMultipleIdFormatting];
-export const showRegionFuncs = [retrieveRegion, getIdFormatting, showRegion];
-export const createRegionFuncs = [postIdFormatting, createRegion];
-export const updateRegionFuncs = [retrieveRegion, postIdFormatting, updateRegion];
+export const indexRegionFuncs = [indexRegion];
+export const showRegionFuncs = [retrieveRegion, showRegion];
+export const createRegionFuncs = [createRegion];
+export const updateRegionFuncs = [retrieveRegion, updateRegion];
 export const destroyRegionFuncs = [retrieveRegion, destroyRegion];

--- a/src/controllers/stallController.ts
+++ b/src/controllers/stallController.ts
@@ -3,6 +3,7 @@ import { upload, sendUploadToGCS, createImages } from './imageController';
 
 import Stall from '../models/Stall';
 import HawkerCentre from '../models/HawkerCentre';
+import { NotFoundError } from '../errors/httpErrors';
 
 import { MAX_NUM_IMAGES, UPLOAD_FORM_FIELD } from '../consts';
 
@@ -23,8 +24,7 @@ async function retrieveStall(req: Request, res: Response, next: NextFunction) {
       include: getStallInclude(),
     });
     if (stall === null) {
-      res.status(404).end();
-      return;
+      throw new NotFoundError('Stall cannot be found');
     }
     req.stall = stall;
     next();

--- a/src/errors/errorUtil.ts
+++ b/src/errors/errorUtil.ts
@@ -1,0 +1,8 @@
+function fmtErrorResp(err: Error) {
+  return {
+    name: err.name,
+    message: err.message,
+  };
+}
+
+export { fmtErrorResp };

--- a/src/errors/httpErrors.ts
+++ b/src/errors/httpErrors.ts
@@ -13,3 +13,16 @@ export class NotFoundError extends HTTPError {
     super(message, 'NotFoundError', 404);
   }
 }
+
+export class BadRequestError extends HTTPError {
+  constructor(message: string) {
+    super(message, 'BadRequestError', 400);
+  }
+}
+
+export class UploadFileError extends HTTPError {
+  constructor(filename: string, err: Error) {
+    const msg = `${filename}: ${err.name}: ${err.message}`;
+    super(msg, 'UploadFileError', 400);
+  }
+}

--- a/src/errors/httpErrors.ts
+++ b/src/errors/httpErrors.ts
@@ -1,0 +1,15 @@
+export class HTTPError extends Error {
+  status: number;
+
+  constructor(message: string, name: string, status: number) {
+    super(message);
+    this.name = name;
+    this.status = status;
+  }
+}
+
+export class NotFoundError extends HTTPError {
+  constructor(message: string) {
+    super(message, 'NotFoundError', 404);
+  }
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -41,7 +41,7 @@ app.all('*', (req: Request, res: Response) => {
   res.status(404).json(fmtErrorResp(err));
 });
 
-app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
+app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
   if (err instanceof HTTPError) {
     res.status(err.status).json(fmtErrorResp(err));
   } else {

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,9 @@ import { PORT } from './consts';
 // import {testAuthenticate} from './db/dbUtil';
 import './models'; // import for side effects
 
+import { HTTPError, NotFoundError } from './errors/httpErrors';
+import { fmtErrorResp } from './errors/errorUtil';
+
 import regions from './routes/regions';
 import hawkerCentres from './routes/hawkerCentres';
 import stalls from './routes/stalls';
@@ -33,11 +36,23 @@ app.use('/categories', categories);
 app.use('/categoryStalls', categoryStalls);
 app.use('/search', search);
 
-app.all('*', (req: Request, res: Response) => res.send('You are at the wrong place. Shoo!'));
+app.all('*', (req: Request, res: Response) => {
+  const err = new NotFoundError('You are at the wrong place. Page cannot be found. Shoo!');
+  res.status(404).json(fmtErrorResp(err));
+});
 
 app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
+  if (err instanceof HTTPError) {
+    res.status(err.status).json(fmtErrorResp(err));
+  } else {
+    next(err);
+  }
+});
+
+// Handle all non-user related errors here (e.g. cannot connect to db)
+app.use((err: Error, req: Request, res: Response, _next: NextFunction) => {
   console.error(err.stack);
-  res.status(500).send('Something broke! Please try again later.');
+  res.status(500).json(fmtErrorResp(err));
 });
 
 if (process.env.NODE_ENV !== 'test') {


### PR DESCRIPTION
- If errors are manually thrown (e.g. params missing), they should inherit from `HTTPError` class so they can have a proper client error code, `4xx`. Will be handled by the error handler for `HTTPError` in `server.ts`.
- All other errors (e.g. library errors that are not caught explicitly by the application code) will have error code `500`. 
- All errors should follow the same format below so that frontend can handle easily.
```json
{
  "name": "class of error", 
  "message": "other details of error"
}
```