### PR TITLE
Refactor stall response

### DIFF
--- a/src/controllers/categoryController.ts
+++ b/src/controllers/categoryController.ts
@@ -1,5 +1,5 @@
 import { Request, Response, NextFunction } from 'express';
-import Category from '../models/Category';
+import { Category } from '../models';
 import { NotFoundError } from '../errors/httpErrors';
 
 async function retrieveCategory(req: Request, res: Response, next: NextFunction) {

--- a/src/controllers/categoryStallController.ts
+++ b/src/controllers/categoryStallController.ts
@@ -1,5 +1,5 @@
-import CategoryStall from '../models/CategoryStall';
 import { Request, Response, NextFunction } from 'express';
+import { CategoryStall } from '../models';
 import { NotFoundError } from '../errors/httpErrors';
 
 async function retrieveCategoryStall(req: Request, res: Response, next: NextFunction) {

--- a/src/controllers/hawkerCentreController.ts
+++ b/src/controllers/hawkerCentreController.ts
@@ -1,4 +1,4 @@
-import HawkerCentre from '../models/HawkerCentre';
+import { HawkerCentre } from '../models';
 import { Request, Response, NextFunction } from 'express';
 import { NotFoundError } from '../errors/httpErrors';
 

--- a/src/controllers/imageController.ts
+++ b/src/controllers/imageController.ts
@@ -6,7 +6,7 @@ import multer from 'multer';
 import mime from 'mime-types';
 import { v4 as uuidv4 } from 'uuid';
 
-import Image from '../models/Image';
+import { Image } from '../models';
 import { ON_GAE, GCS_BUCKET, GCS_CLIENT_EMAIL, GCS_PRIVATE_KEY, MAX_IMAGE_SIZE } from '../consts';
 import { BadRequestError, UploadFileError } from '../errors/httpErrors';
 import { BulkCreateOptions, DestroyOptions } from 'sequelize/types';

--- a/src/controllers/productController.ts
+++ b/src/controllers/productController.ts
@@ -6,8 +6,7 @@ import {
   destroyImageIds,
   destroyImages,
 } from './imageController';
-import Product from '../models/Product';
-import Stall from '../models/Stall';
+import { Product, Stall } from '../models';
 import { BadRequestError, NotFoundError } from '../errors/httpErrors';
 
 import { MAX_NUM_IMAGES, UPLOAD_FORM_FIELD } from '../consts';

--- a/src/controllers/regionController.ts
+++ b/src/controllers/regionController.ts
@@ -1,4 +1,4 @@
-import Region from '../models/Region';
+import { Region } from '../models/';
 import { Request, Response, NextFunction } from 'express';
 import { NotFoundError } from '../errors/httpErrors';
 

--- a/src/controllers/resetController.ts
+++ b/src/controllers/resetController.ts
@@ -5,7 +5,7 @@ import fs from 'fs';
 import inflection from 'inflection';
 import { Transaction } from 'sequelize/types';
 
-import { ModelStatic } from '../types';
+import { Models } from '../types';
 import sequelize from '../db';
 import models from '../models';
 import { Image, Product, Stall } from '../models';
@@ -21,8 +21,9 @@ async function seedClazz(clazzName: string, t?: Transaction) {
 
   await fs.promises.access(filepath);
   const data = await retrieveDataFromCsv(filepath);
-  //@ts-ignore
-  await (models[clazzName] as ModelStatic).bulkCreate(data, { transaction: t });
+
+  const modelszz = models as Models; // force typecast so can index into models using string
+  await modelszz[clazzName].bulkCreate(data, { transaction: t });
 }
 
 async function createSampleImages(nImages: number, t: Transaction) {

--- a/src/controllers/resetController.ts
+++ b/src/controllers/resetController.ts
@@ -5,6 +5,7 @@ import fs from 'fs';
 import inflection from 'inflection';
 import { Transaction } from 'sequelize/types';
 
+import { ModelStatic } from '../types';
 import sequelize from '../db';
 import models from '../models';
 import { Image, Product, Stall } from '../models';
@@ -14,19 +15,13 @@ import { uploadDiskImg, destroyImages, createImages } from '../controllers/image
 const SEEDS_FILE_PATH = '../db/seeds/';
 const SAMPLE_IMG_FILE_PATH = path.resolve(__dirname, SEEDS_FILE_PATH, 'cat.jpg');
 
-interface StaticModel {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  bulkCreate(data: any, options: any): void;
-}
-
 async function seedClazz(clazzName: string, t?: Transaction) {
   const filename = `${inflection.pluralize(clazzName)}.csv`;
   const filepath = path.resolve(__dirname, SEEDS_FILE_PATH, filename);
 
   await fs.promises.access(filepath);
   const data = await retrieveDataFromCsv(filepath);
-  const clazz = models[clazzName] as unknown;
-  await (clazz as StaticModel).bulkCreate(data, { transaction: t });
+  await (models[clazzName] as ModelStatic).bulkCreate(data, { transaction: t });
 }
 
 async function createSampleImages(nImages: number, t: Transaction) {

--- a/src/controllers/resetController.ts
+++ b/src/controllers/resetController.ts
@@ -7,9 +7,7 @@ import { Transaction } from 'sequelize/types';
 
 import sequelize from '../db';
 import models from '../models';
-import Image from '../models/Image';
-import Product from '../models/Product';
-import Stall from '../models/Stall';
+import { Image, Product, Stall } from '../models';
 import { truncateClazzes } from '../utils/dbUtil';
 import { uploadDiskImg, destroyImages, createImages } from '../controllers/imageController';
 

--- a/src/controllers/resetController.ts
+++ b/src/controllers/resetController.ts
@@ -21,6 +21,7 @@ async function seedClazz(clazzName: string, t?: Transaction) {
 
   await fs.promises.access(filepath);
   const data = await retrieveDataFromCsv(filepath);
+  //@ts-ignore
   await (models[clazzName] as ModelStatic).bulkCreate(data, { transaction: t });
 }
 

--- a/src/controllers/resetController.ts
+++ b/src/controllers/resetController.ts
@@ -56,6 +56,8 @@ async function seedDevData(t: Transaction) {
   await seedClazz('Stall', t);
   await seedClazz('CategoryStall', t);
   await seedClazz('Product', t);
+  await seedClazz('User', t);
+  await seedClazz('Review', t);
 }
 
 async function reset(req: Request, res: Response, next: NextFunction) {

--- a/src/controllers/reviewController.ts
+++ b/src/controllers/reviewController.ts
@@ -1,4 +1,4 @@
-import Review from '../models/Review';
+import { Review } from '../models';
 import { Request, Response, NextFunction } from 'express';
 import { NotFoundError, BadRequestError } from '../errors/httpErrors';
 import { UniqueConstraintError } from 'sequelize';

--- a/src/controllers/searchController.ts
+++ b/src/controllers/searchController.ts
@@ -1,9 +1,6 @@
-import { Request, Response, NextFunction } from 'express';
-import Category from '../models/Category';
-import Stall from '../models/Stall';
 import { Sequelize } from 'sequelize';
-import HawkerCentre from '../models/HawkerCentre';
-import Review from '../models/Review';
+import { Request, Response, NextFunction } from 'express';
+import { HawkerCentre, Review, Stall, Category } from '../models';
 
 function getStallInclude() {
   return [

--- a/src/controllers/searchController.ts
+++ b/src/controllers/searchController.ts
@@ -1,70 +1,117 @@
 import { Sequelize } from 'sequelize';
 import { Request, Response, NextFunction } from 'express';
 import { HawkerCentre, Review, Stall, Category } from '../models';
-
-function getStallInclude() {
-  return [
-    { association: Stall.associations.Images, attributes: ['id', 'downloadUrl'] },
-    {
-      association: Stall.associations.HawkerCentre,
-      include: [HawkerCentre.associations.Region],
-    },
-    {
-      association: Stall.associations.Categories,
-    },
-  ];
-}
+import { getStallsInclude, fmtStallsResp } from './stallController';
 
 async function searchStalls(req: Request, res: Response, next: NextFunction) {
+  // try {
+  //   if (req.params.query) {
+  //     const query = cleanInput(req.params.query);
+  //     const stallIds = await Stall.sequelize!.query(
+  //       `
+  //       SELECT id
+  //       FROM "Stalls"
+  //       WHERE id IN (
+  //         SELECT "stallId"
+  //         FROM "Products"
+  //         WHERE _search @@ to_tsquery('english', '${query}')
+  //       ) OR id IN (
+  //         SELECT id
+  //         FROM "Stalls"
+  //         WHERE _search @@ to_tsquery('english', '${query}')
+  //       ) OR id IN (
+  //         SELECT "stallId"
+  //         FROM "CategoryStalls"
+  //         WHERE "categoryId" IN (
+  //           SELECT id
+  //           FROM "Categories"
+  //           WHERE _search @@ to_tsquery('english', 'drinks')
+  //         )
+  //       ) OR "hawkerCentreId" IN (
+  //         SELECT id
+  //         FROM "HawkerCentres"
+  //         WHERE _search @@ to_tsquery('english', '${query}')
+  //       ) OR "hawkerCentreId" IN (
+  //         SELECT id
+  //         FROM "HawkerCentres"
+  //         WHERE "regionId" IN (
+  //           SELECT id
+  //           FROM "Regions"
+  //           WHERE _search @@ to_tsquery('english', '${query}')
+  //         )
+  //       )
+  //     `,
+  //       {
+  //         model: Stall,
+  //         replacements: { query: query },
+  //       }
+  //     );
+  //     const stallIdsArray = stallIds.reduce((acc: number[], cur) => {
+  //       acc.push(cur.getDataValue('id'));
+  //       return acc;
+  //     }, []);
+  //     req.stallIds = stallIdsArray;
+  //   }
+  //   next();
+  // } catch (err) {
+  //   next(err);
+  // }
+
   try {
-    if (req.params.query) {
-      const query = cleanInput(req.params.query);
-      const stallIds = await Stall.sequelize!.query(
-        `
-        SELECT id
-        FROM "Stalls"
-        WHERE id IN (
-          SELECT "stallId"
-          FROM "Products"
-          WHERE _search @@ to_tsquery('english', '${query}')
-        ) OR id IN (
+    const rawQuery: string | undefined = req.params.query?.trim();
+
+    if (!rawQuery) {
+      const stalls = await Stall.findAll({ include: getStallsInclude() });
+      res.status(200).json(await fmtStallsResp(stalls));
+      return;
+    }
+
+    const query = cleanInput(rawQuery);
+    const result = await Stall.sequelize!.query(
+      `
           SELECT id
           FROM "Stalls"
-          WHERE _search @@ to_tsquery('english', '${query}')
-        ) OR id IN (
-          SELECT "stallId"
-          FROM "CategoryStalls"
-          WHERE "categoryId" IN (
-            SELECT id
-            FROM "Categories"
-            WHERE _search @@ to_tsquery('english', 'drinks')
-          )
-        ) OR "hawkerCentreId" IN (
-          SELECT id
-          FROM "HawkerCentres"
-          WHERE _search @@ to_tsquery('english', '${query}')
-        ) OR "hawkerCentreId" IN (
-          SELECT id
-          FROM "HawkerCentres"
-          WHERE "regionId" IN (
-            SELECT id
-            FROM "Regions"
+          WHERE id IN (
+            SELECT "stallId"
+            FROM "Products"
             WHERE _search @@ to_tsquery('english', '${query}')
+          ) OR id IN (
+            SELECT id
+            FROM "Stalls"
+            WHERE _search @@ to_tsquery('english', '${query}')
+          ) OR id IN (
+            SELECT "stallId"
+            FROM "CategoryStalls"
+            WHERE "categoryId" IN (
+              SELECT id
+              FROM "Categories"
+              WHERE _search @@ to_tsquery('english', '${query}')
+            )
+          ) OR "hawkerCentreId" IN (
+            SELECT id
+            FROM "HawkerCentres"
+            WHERE _search @@ to_tsquery('english', '${query}')
+          ) OR "hawkerCentreId" IN (
+            SELECT id
+            FROM "HawkerCentres"
+            WHERE "regionId" IN (
+              SELECT id
+              FROM "Regions"
+              WHERE _search @@ to_tsquery('english', '${query}')
+            )
           )
-        )
-      `,
-        {
-          model: Stall,
-          replacements: { query: query },
-        }
-      );
-      const stallIdsArray = stallIds.reduce((acc: number[], cur) => {
-        acc.push(cur.getDataValue('id'));
-        return acc;
-      }, []);
-      req.stallIds = stallIdsArray;
-    }
-    next();
+        `,
+      {
+        model: Stall,
+        replacements: { query: query },
+      }
+    );
+    const stallIds = result.reduce((acc: number[], cur) => {
+      acc.push(cur.getDataValue('id'));
+      return acc;
+    }, []);
+    const stalls = await Stall.findAll({ where: { id: stallIds }, include: getStallsInclude() });
+    res.status(200).json(await fmtStallsResp(stalls));
   } catch (err) {
     next(err);
   }
@@ -74,58 +121,58 @@ async function searchStalls(req: Request, res: Response, next: NextFunction) {
  * Retrieves all stalls that match a given set of ids.
  * @param ids Ids of stalls to be retrieved.
  */
-async function findStallsByIds(req: Request, res: Response, next: NextFunction) {
-  try {
-    const stallIdsArray = req.stallIds;
-    const stalls = await Stall.findAll({
-      include: getStallInclude(),
-      where: stallIdsArray ? { id: stallIdsArray } : {},
-    });
+// async function findStallsByIds(req: Request, res: Response, next: NextFunction) {
+//   try {
+//     const stallIdsArray = req.stallIds;
+//     const stalls = await Stall.findAll({
+//       include: getStallInclude(),
+//       where: stallIdsArray ? { id: stallIdsArray } : {},
+//     });
 
-    // To obtain all stall ratings
-    const ratings = await Review.findAll({
-      where: stallIdsArray ? { stallId: stallIdsArray } : {},
-      attributes: [
-        'stallId',
-        [Sequelize.fn('ROUND', Sequelize.fn('AVG', Sequelize.col('rating')), 2), 'rating'],
-      ],
-      group: ['stallId'],
-    });
+//     // To obtain all stall ratings
+//     const ratings = await Review.findAll({
+//       where: stallIdsArray ? { stallId: stallIdsArray } : {},
+//       attributes: [
+//         'stallId',
+//         [Sequelize.fn('ROUND', Sequelize.fn('AVG', Sequelize.col('rating')), 2), 'rating'],
+//       ],
+//       group: ['stallId'],
+//     });
 
-    stalls.map(async (stall: Stall) => {
-      const filteredRating = ratings.filter(rating => rating.stallId === stall.id);
-      const rating: number = filteredRating.length ? filteredRating[0].rating : 0;
-      await stall.setDataValue('rating', rating);
-    });
-    req.stalls = stalls;
-    next();
-  } catch (err) {
-    next(err);
-  }
-}
+//     stalls.map(async (stall: Stall) => {
+//       const filteredRating = ratings.filter(rating => rating.stallId === stall.id);
+//       const rating: number = filteredRating.length ? filteredRating[0].rating : 0;
+//       await stall.setDataValue('rating', rating);
+//     });
+//     req.stalls = stalls;
+//     next();
+//   } catch (err) {
+//     next(err);
+//   }
+// }
 
 /**
  * Formats stall information to display them on cards.
  * @param stalls Sequelize instances of stalls to be formmatted.
  */
-async function mapStallToCard(req: Request, res: Response, next: NextFunction) {
-  try {
-    const stalls = req.stalls!;
-    const updatedStalls = stalls.map(stall => {
-      const jsonStall = JSON.parse(JSON.stringify(stall));
+// async function mapStallToCard(req: Request, res: Response, next: NextFunction) {
+//   try {
+//     const stalls = req.stalls!;
+//     const updatedStalls = stalls.map(stall => {
+//       const jsonStall = JSON.parse(JSON.stringify(stall));
 
-      jsonStall['Categories'] = jsonStall['Categories'].map(
-        (category: Category) => category['name']
-      );
-      const propertiesToDelete = ['description', 'contactNo', 'unitNo'];
-      propertiesToDelete.forEach(property => delete jsonStall[property]);
-      return jsonStall;
-    });
-    res.status(200).json(updatedStalls);
-  } catch (err) {
-    next(err);
-  }
-}
+//       jsonStall['Categories'] = jsonStall['Categories'].map(
+//         (category: Category) => category['name']
+//       );
+//       const propertiesToDelete = ['description', 'contactNo', 'unitNo'];
+//       propertiesToDelete.forEach(property => delete jsonStall[property]);
+//       return jsonStall;
+//     });
+//     res.status(200).json(updatedStalls);
+//   } catch (err) {
+//     next(err);
+//   }
+// }
 
 /**
  * Removes boolean operators from user query for to_tsquery.
@@ -135,4 +182,4 @@ function cleanInput(input: String) {
   return input.replace(/[|&!<>]+/g, '').replace(/ /g, '|');
 }
 
-export const searchFuncs = [searchStalls, findStallsByIds, mapStallToCard];
+export const searchFuncs = [searchStalls];

--- a/src/controllers/searchController.ts
+++ b/src/controllers/searchController.ts
@@ -1,5 +1,6 @@
 import { Request, Response, NextFunction } from 'express';
 import { getStallsInclude, fmtStallsResp } from './stallController';
+import { Stall } from '../models';
 
 async function searchStalls(req: Request, res: Response, next: NextFunction) {
   try {

--- a/src/controllers/searchController.ts
+++ b/src/controllers/searchController.ts
@@ -1,62 +1,7 @@
-import { Sequelize } from 'sequelize';
 import { Request, Response, NextFunction } from 'express';
-import { HawkerCentre, Review, Stall, Category } from '../models';
 import { getStallsInclude, fmtStallsResp } from './stallController';
 
 async function searchStalls(req: Request, res: Response, next: NextFunction) {
-  // try {
-  //   if (req.params.query) {
-  //     const query = cleanInput(req.params.query);
-  //     const stallIds = await Stall.sequelize!.query(
-  //       `
-  //       SELECT id
-  //       FROM "Stalls"
-  //       WHERE id IN (
-  //         SELECT "stallId"
-  //         FROM "Products"
-  //         WHERE _search @@ to_tsquery('english', '${query}')
-  //       ) OR id IN (
-  //         SELECT id
-  //         FROM "Stalls"
-  //         WHERE _search @@ to_tsquery('english', '${query}')
-  //       ) OR id IN (
-  //         SELECT "stallId"
-  //         FROM "CategoryStalls"
-  //         WHERE "categoryId" IN (
-  //           SELECT id
-  //           FROM "Categories"
-  //           WHERE _search @@ to_tsquery('english', 'drinks')
-  //         )
-  //       ) OR "hawkerCentreId" IN (
-  //         SELECT id
-  //         FROM "HawkerCentres"
-  //         WHERE _search @@ to_tsquery('english', '${query}')
-  //       ) OR "hawkerCentreId" IN (
-  //         SELECT id
-  //         FROM "HawkerCentres"
-  //         WHERE "regionId" IN (
-  //           SELECT id
-  //           FROM "Regions"
-  //           WHERE _search @@ to_tsquery('english', '${query}')
-  //         )
-  //       )
-  //     `,
-  //       {
-  //         model: Stall,
-  //         replacements: { query: query },
-  //       }
-  //     );
-  //     const stallIdsArray = stallIds.reduce((acc: number[], cur) => {
-  //       acc.push(cur.getDataValue('id'));
-  //       return acc;
-  //     }, []);
-  //     req.stallIds = stallIdsArray;
-  //   }
-  //   next();
-  // } catch (err) {
-  //   next(err);
-  // }
-
   try {
     const rawQuery: string | undefined = req.params.query?.trim();
 
@@ -116,63 +61,6 @@ async function searchStalls(req: Request, res: Response, next: NextFunction) {
     next(err);
   }
 }
-
-/**
- * Retrieves all stalls that match a given set of ids.
- * @param ids Ids of stalls to be retrieved.
- */
-// async function findStallsByIds(req: Request, res: Response, next: NextFunction) {
-//   try {
-//     const stallIdsArray = req.stallIds;
-//     const stalls = await Stall.findAll({
-//       include: getStallInclude(),
-//       where: stallIdsArray ? { id: stallIdsArray } : {},
-//     });
-
-//     // To obtain all stall ratings
-//     const ratings = await Review.findAll({
-//       where: stallIdsArray ? { stallId: stallIdsArray } : {},
-//       attributes: [
-//         'stallId',
-//         [Sequelize.fn('ROUND', Sequelize.fn('AVG', Sequelize.col('rating')), 2), 'rating'],
-//       ],
-//       group: ['stallId'],
-//     });
-
-//     stalls.map(async (stall: Stall) => {
-//       const filteredRating = ratings.filter(rating => rating.stallId === stall.id);
-//       const rating: number = filteredRating.length ? filteredRating[0].rating : 0;
-//       await stall.setDataValue('rating', rating);
-//     });
-//     req.stalls = stalls;
-//     next();
-//   } catch (err) {
-//     next(err);
-//   }
-// }
-
-/**
- * Formats stall information to display them on cards.
- * @param stalls Sequelize instances of stalls to be formmatted.
- */
-// async function mapStallToCard(req: Request, res: Response, next: NextFunction) {
-//   try {
-//     const stalls = req.stalls!;
-//     const updatedStalls = stalls.map(stall => {
-//       const jsonStall = JSON.parse(JSON.stringify(stall));
-
-//       jsonStall['Categories'] = jsonStall['Categories'].map(
-//         (category: Category) => category['name']
-//       );
-//       const propertiesToDelete = ['description', 'contactNo', 'unitNo'];
-//       propertiesToDelete.forEach(property => delete jsonStall[property]);
-//       return jsonStall;
-//     });
-//     res.status(200).json(updatedStalls);
-//   } catch (err) {
-//     next(err);
-//   }
-// }
 
 /**
  * Removes boolean operators from user query for to_tsquery.

--- a/src/controllers/stallController.ts
+++ b/src/controllers/stallController.ts
@@ -1,9 +1,10 @@
 import { Request, Response, NextFunction } from 'express';
 import { upload, uploadFormImgs, createImages, destroyImageIds } from './imageController';
 
-import Stall from '../models/Stall';
-import HawkerCentre from '../models/HawkerCentre';
-import Review from '../models/Review';
+// import Stall from '../models/Stall';
+// import HawkerCentre from '../models/HawkerCentre';
+// import Review from '../models/Review';
+import { Stall, HawkerCentre, Review } from '../models';
 import { BadRequestError, NotFoundError } from '../errors/httpErrors';
 import { Sequelize } from 'sequelize';
 
@@ -11,6 +12,9 @@ import { MAX_NUM_IMAGES, UPLOAD_FORM_FIELD } from '../consts';
 import Product from '../models/Product';
 import sequelize from '../db';
 
+/*
+ * Returns the includes needed to fetch associated models for a single stall response
+ */
 function getStallInclude() {
   return [
     { association: Stall.associations.Products },
@@ -28,29 +32,40 @@ function getStallInclude() {
   ];
 }
 
+/*
+ * Returns the includes needed to fetch associated models for a multiple stalls response
+ */
+function getStallsInclude() {
+}
+
 async function retrieveStall(req: Request, res: Response, next: NextFunction) {
   try {
-    const stall = await Stall.findByPk(req.params.id, {
-      include: getStallInclude(),
-    });
+    // const stall = await Stall.findByPk(req.params.id, {
+    //   include: getStallInclude(),
+    // });
+
+    const stall = await Stall.scope('asdf').findAll({ where: { id: req.params.id } });
+
+    // console.log(stall?.getDataValue('Categories'));
+    console.log(stall);
 
     if (stall === null) {
       throw new NotFoundError('Stall cannot be found');
     }
 
     // To obtain single stall rating
-    const rating = (
-      await Review.findAll({
-        where: {
-          stallId: stall!.id,
-        },
-        attributes: [
-          [Sequelize.fn('ROUND', Sequelize.fn('AVG', Sequelize.col('rating')), 2), 'rating'],
-        ],
-      })
-    )[0].rating;
+    // const rating = (
+    //   await Review.findAll({
+    //     where: {
+    //       stallId: stall!.id,
+    //     },
+    //     attributes: [
+    //       [Sequelize.fn('ROUND', Sequelize.fn('AVG', Sequelize.col('rating')), 2), 'rating'],
+    //     ],
+    //   })
+    // )[0].rating;
 
-    await stall.setDataValue('rating', rating || 0);
+    // await stall.setDataValue('rating', rating || 0);
 
     req.stall = stall;
     next();
@@ -81,7 +96,6 @@ async function indexStall(req: Request, res: Response, next: NextFunction) {
     });
 
     res.status(200).json(stalls);
-    next();
   } catch (err) {
     next(err);
   }

--- a/src/controllers/stallController.ts
+++ b/src/controllers/stallController.ts
@@ -71,8 +71,9 @@ async function getCategories(stall: Stall) {
   return stall.Categories!.map(cate => cate.name);
 }
 
-/*
- *
+/**
+ * Format a single stall response
+ * @param stall Stall instance
  */
 async function fmtStallResp(stall: Stall) {
   const rating = await getRating(stall);
@@ -88,6 +89,10 @@ async function fmtStallResp(stall: Stall) {
   return stallObj;
 }
 
+/**
+ * Format multiple stalls response
+ * @param stalls An array of Stall instances
+ */
 async function fmtStallsResp(stalls: Stall[]) {
   const propertiesToDelete = ['description', 'contactNo', 'unitNo', 'Categories', 'Reviews'];
 

--- a/src/controllers/stallController.ts
+++ b/src/controllers/stallController.ts
@@ -58,7 +58,6 @@ function getStallsInclude(): Includeable[] {
 }
 
 async function getRating(stall: Stall) {
-  // Code this out later
   if (stall.Reviews === undefined) {
     await stall.reload({ include: Stall.associations.Reviews });
   }
@@ -79,7 +78,7 @@ async function getCategories(stall: Stall) {
 /*
  *
  */
-async function fmtStallJson(stall: Stall) {
+async function fmtStallResp(stall: Stall) {
   const rating = await getRating(stall);
   const categories = await getCategories(stall);
 
@@ -93,7 +92,7 @@ async function fmtStallJson(stall: Stall) {
   return stallObj;
 }
 
-async function fmtStallsJson(stalls: Stall[]) {
+async function fmtStallsResp(stalls: Stall[]) {
   const propertiesToDelete = ['description', 'contactNo', 'unitNo', 'Categories', 'Reviews'];
 
   const result = await Promise.all(
@@ -167,7 +166,7 @@ async function indexStall(req: Request, res: Response, next: NextFunction) {
     //   await stall.setDataValue('rating', rating);
     // });
 
-    res.status(200).json(await fmtStallsJson(stalls));
+    res.status(200).json(await fmtStallsResp(stalls));
   } catch (err) {
     next(err);
   }
@@ -175,7 +174,7 @@ async function indexStall(req: Request, res: Response, next: NextFunction) {
 
 async function showStall(req: Request, res: Response, next: NextFunction) {
   try {
-    res.status(200).json(await fmtStallJson(req.stall!));
+    res.status(200).json(await fmtStallResp(req.stall!));
   } catch (err) {
     next(err);
   }
@@ -185,7 +184,7 @@ async function createStall(req: Request, res: Response, next: NextFunction) {
   try {
     const stall = await Stall.create(req.body);
     await stall.reload({ include: getStallInclude() });
-    res.status(201).json(await fmtStallJson(stall));
+    res.status(201).json(await fmtStallResp(stall));
   } catch (err) {
     next(err);
   }
@@ -195,7 +194,7 @@ async function updateStall(req: Request, res: Response, next: NextFunction) {
   try {
     const stall = await req.stall!.update(req.body);
     await stall.reload({ include: getStallInclude() });
-    res.status(200).json(await fmtStallJson(stall));
+    res.status(200).json(await fmtStallResp(stall));
   } catch (err) {
     next(err);
   }
@@ -232,7 +231,7 @@ async function uploadStallImages(req: Request, res: Response, next: NextFunction
     });
 
     await stall.reload({ include: getStallInclude() });
-    res.status(200).json(await fmtStallJson(stall));
+    res.status(200).json(await fmtStallResp(stall));
   } catch (err) {
     next(err);
   }
@@ -251,6 +250,8 @@ async function destroyStallImages(req: Request, res: Response, next: NextFunctio
     next(err);
   }
 }
+
+export { getStallInclude, getStallsInclude, fmtStallResp, fmtStallsResp };
 
 export const indexStallFuncs = [indexStall];
 export const showStallFuncs = [retrieveStall, showStall];

--- a/src/controllers/stallController.ts
+++ b/src/controllers/stallController.ts
@@ -1,12 +1,8 @@
 import { Request, Response, NextFunction } from 'express';
 import { upload, uploadFormImgs, createImages, destroyImageIds } from './imageController';
 
-// import Stall from '../models/Stall';
-// import HawkerCentre from '../models/HawkerCentre';
-// import Review from '../models/Review';
 import { Stall, HawkerCentre, Review } from '../models';
 import { BadRequestError, NotFoundError } from '../errors/httpErrors';
-import { Sequelize } from 'sequelize';
 import { Includeable } from 'sequelize/types';
 
 import { MAX_NUM_IMAGES, UPLOAD_FORM_FIELD } from '../consts';
@@ -124,20 +120,6 @@ async function retrieveStall(req: Request, res: Response, next: NextFunction) {
       throw new NotFoundError('Stall cannot be found');
     }
 
-    // To obtain single stall rating
-    // const rating = (
-    //   await Review.findAll({
-    //     where: {
-    //       stallId: stall!.id,
-    //     },
-    //     attributes: [
-    //       [Sequelize.fn('ROUND', Sequelize.fn('AVG', Sequelize.col('rating')), 2), 'rating'],
-    //     ],
-    //   })
-    // )[0].rating;
-
-    // await stall.setDataValue('rating', rating || 0);
-
     req.stall = stall;
     next();
   } catch (err) {
@@ -150,21 +132,6 @@ async function indexStall(req: Request, res: Response, next: NextFunction) {
     const stalls = await Stall.findAll({
       include: getStallsInclude(),
     });
-
-    // To obtain all stall ratings
-    // const ratings = await Review.findAll({
-    //   attributes: [
-    //     'stallId',
-    //     [Sequelize.fn('ROUND', Sequelize.fn('AVG', Sequelize.col('rating')), 2), 'rating'],
-    //   ],
-    //   group: ['stallId'],
-    // });
-
-    // stalls.map(async (stall: Stall) => {
-    //   const filteredRating = ratings.filter(rating => rating.stallId === stall.id);
-    //   const rating = filteredRating.length ? filteredRating[0].rating : 0;
-    //   await stall.setDataValue('rating', rating);
-    // });
 
     res.status(200).json(await fmtStallsResp(stalls));
   } catch (err) {

--- a/src/controllers/stallController.ts
+++ b/src/controllers/stallController.ts
@@ -44,7 +44,7 @@ async function retrieveStall(req: Request, res: Response, next: NextFunction) {
     //   include: getStallInclude(),
     // });
 
-    const stall = await Stall.scope('asdf').findAll({ where: { id: req.params.id } });
+    const stall = await Stall.findAll({ where: { id: req.params.id } });
 
     // console.log(stall?.getDataValue('Categories'));
     console.log(stall);

--- a/src/controllers/userController.ts
+++ b/src/controllers/userController.ts
@@ -3,7 +3,7 @@ import { UniqueConstraintError } from 'sequelize';
 import jwt from 'jsonwebtoken';
 import bcrypt from 'bcryptjs';
 
-import User from '../models/User';
+import { User } from '../models';
 import { BadRequestError, UnauthorizedError } from '../errors/httpErrors';
 import { ACCESS_TOKEN_SECRET } from '../consts';
 

--- a/src/db/seeds/CategoryStalls.csv
+++ b/src/db/seeds/CategoryStalls.csv
@@ -1,4 +1,4 @@
-﻿stallId,cateoryId
+﻿stallId,categoryId
 1,4
 2,1
 3,1

--- a/src/db/seeds/CategoryStalls.csv
+++ b/src/db/seeds/CategoryStalls.csv
@@ -1,4 +1,6 @@
 ﻿stallId,categoryId
+1,1
+1,3
 1,4
 2,1
 3,1

--- a/src/db/seeds/Reviews.csv
+++ b/src/db/seeds/Reviews.csv
@@ -1,0 +1,4 @@
+description,rating,stallId,userId
+"good food",5,1,1
+"awesome",4,1,2
+"insane food",4,1,3

--- a/src/db/seeds/Users.csv
+++ b/src/db/seeds/Users.csv
@@ -1,0 +1,4 @@
+email,password
+Stevie75@gmail.com,fRDBnAWsdSDSljp
+Braden_OKon80@outlook.com,JU7xn0589tDak0n
+Alexandre59@gmail.com,V2refAIC5vpNSsH

--- a/src/models/HawkerCentre.ts
+++ b/src/models/HawkerCentre.ts
@@ -105,7 +105,7 @@ HawkerCentre.init(
   { sequelize }
 );
 
-HawkerCentre.hasMany(Stall, { foreignKey: 'hawkerCentreId' });
-Stall.belongsTo(HawkerCentre, { foreignKey: 'hawkerCentreId' });
+// HawkerCentre.hasMany(Stall, { foreignKey: 'hawkerCentreId' });
+// Stall.belongsTo(HawkerCentre, { foreignKey: 'hawkerCentreId' });
 
 export default HawkerCentre;

--- a/src/models/HawkerCentre.ts
+++ b/src/models/HawkerCentre.ts
@@ -105,7 +105,4 @@ HawkerCentre.init(
   { sequelize }
 );
 
-// HawkerCentre.hasMany(Stall, { foreignKey: 'hawkerCentreId' });
-// Stall.belongsTo(HawkerCentre, { foreignKey: 'hawkerCentreId' });
-
 export default HawkerCentre;

--- a/src/models/Product.ts
+++ b/src/models/Product.ts
@@ -100,6 +100,5 @@ Product.init(
   { sequelize }
 );
 
-Product.hasMany(Image, { foreignKey: 'productId' });
-
+// Product.hasMany(Image, { foreignKey: 'productId' });
 export default Product;

--- a/src/models/Product.ts
+++ b/src/models/Product.ts
@@ -100,5 +100,4 @@ Product.init(
   { sequelize }
 );
 
-// Product.hasMany(Image, { foreignKey: 'productId' });
 export default Product;

--- a/src/models/Region.ts
+++ b/src/models/Region.ts
@@ -67,7 +67,7 @@ Region.init(
   { sequelize }
 );
 
-Region.hasMany(HawkerCentre, { foreignKey: 'regionId' });
-HawkerCentre.belongsTo(Region, { foreignKey: 'regionId' });
+// Region.hasMany(HawkerCentre, { foreignKey: 'regionId' });
+// HawkerCentre.belongsTo(Region, { foreignKey: 'regionId' });
 
 export default Region;

--- a/src/models/Region.ts
+++ b/src/models/Region.ts
@@ -67,7 +67,4 @@ Region.init(
   { sequelize }
 );
 
-// Region.hasMany(HawkerCentre, { foreignKey: 'regionId' });
-// HawkerCentre.belongsTo(Region, { foreignKey: 'regionId' });
-
 export default Region;

--- a/src/models/Stall.ts
+++ b/src/models/Stall.ts
@@ -34,7 +34,6 @@ import HawkerCentre from './HawkerCentre';
 import Image from './Image';
 import Review from './Review';
 import Category from './Category';
-import { showCategoryStallFuncs } from '../controllers/categoryStallController';
 // import CategoryStall from './CategoryStall';
 
 export interface StallAttributes {
@@ -173,16 +172,16 @@ Stall.init(
   { sequelize }
 );
 
-Stall.hasMany(Product, { foreignKey: 'stallId', onDelete: 'cascade', hooks: true });
-Product.belongsTo(Stall, { foreignKey: 'stallId' });
+// Stall.hasMany(Product, { foreignKey: 'stallId', onDelete: 'cascade', hooks: true });
+// Product.belongsTo(Stall, { foreignKey: 'stallId' });
 
-Stall.hasMany(Image, { foreignKey: 'stallId' });
+// Stall.hasMany(Image, { foreignKey: 'stallId' });
 
-Stall.belongsToMany(Category, { through: 'CategoryStalls', foreignKey: 'stallId' });
-Category.belongsToMany(Stall, { through: 'CategoryStalls', foreignKey: 'categoryId' });
+// Stall.belongsToMany(Category, { through: 'CategoryStalls', foreignKey: 'stallId' });
+// Category.belongsToMany(Stall, { through: 'CategoryStalls', foreignKey: 'categoryId' });
 
-Stall.hasMany(Review, { foreignKey: 'stallId' });
-Review.belongsTo(Stall, { foreignKey: 'stallId' });
+// Stall.hasMany(Review, { foreignKey: 'stallId' });
+// Review.belongsTo(Stall, { foreignKey: 'stallId' });
 
 // Stall.addScope('asdf', { include: [{ association: Stall.associations.Categories }] });
 

--- a/src/models/Stall.ts
+++ b/src/models/Stall.ts
@@ -34,7 +34,6 @@ import HawkerCentre from './HawkerCentre';
 import Image from './Image';
 import Review from './Review';
 import Category from './Category';
-// import CategoryStall from './CategoryStall';
 
 export interface StallAttributes {
   id: number;
@@ -42,8 +41,6 @@ export interface StallAttributes {
   description: string | null;
   contactNo: string | null;
   unitNo: string | null;
-  // rating: number;
-  // categories: string[];
   hawkerCentreId: number;
 }
 
@@ -55,8 +52,6 @@ class Stall extends Model<StallAttributes, StallCreationAttributes> implements S
   public description!: string | null;
   public contactNo!: string | null;
   public unitNo!: string | null;
-  // public rating!: number;
-  // public categories!: string[];
   public hawkerCentreId!: number;
 
   public readonly createdAt!: Date;
@@ -151,17 +146,6 @@ Stall.init(
     unitNo: {
       type: DataTypes.INTEGER,
     },
-    // rating: {
-    //   type: DataTypes.VIRTUAL,
-    // },
-    // categories: {
-    //   type: DataTypes.VIRTUAL,
-    //   get() {
-    //     // this assumes that the call includes Categories
-    //     const categories = this.getDataValue('Categories') as Category[];
-    //     return categories.map(cate => cate.name);
-    //   },
-    // },
     hawkerCentreId: {
       type: DataTypes.INTEGER,
       allowNull: false,
@@ -173,18 +157,5 @@ Stall.init(
   },
   { sequelize }
 );
-
-// Stall.hasMany(Product, { foreignKey: 'stallId', onDelete: 'cascade', hooks: true });
-// Product.belongsTo(Stall, { foreignKey: 'stallId' });
-
-// Stall.hasMany(Image, { foreignKey: 'stallId' });
-
-// Stall.belongsToMany(Category, { through: 'CategoryStalls', foreignKey: 'stallId' });
-// Category.belongsToMany(Stall, { through: 'CategoryStalls', foreignKey: 'categoryId' });
-
-// Stall.hasMany(Review, { foreignKey: 'stallId' });
-// Review.belongsTo(Stall, { foreignKey: 'stallId' });
-
-// Stall.addScope('asdf', { include: [{ association: Stall.associations.Categories }] });
 
 export default Stall;

--- a/src/models/Stall.ts
+++ b/src/models/Stall.ts
@@ -42,7 +42,7 @@ export interface StallAttributes {
   description: string | null;
   contactNo: string | null;
   unitNo: string | null;
-  rating: number;
+  // rating: number;
   // categories: string[];
   hawkerCentreId: number;
 }
@@ -55,7 +55,7 @@ class Stall extends Model<StallAttributes, StallCreationAttributes> implements S
   public description!: string | null;
   public contactNo!: string | null;
   public unitNo!: string | null;
-  public rating!: number;
+  // public rating!: number;
   // public categories!: string[];
   public hawkerCentreId!: number;
 
@@ -151,9 +151,9 @@ Stall.init(
     unitNo: {
       type: DataTypes.INTEGER,
     },
-    rating: {
-      type: DataTypes.VIRTUAL,
-    },
+    // rating: {
+    //   type: DataTypes.VIRTUAL,
+    // },
     // categories: {
     //   type: DataTypes.VIRTUAL,
     //   get() {

--- a/src/models/Stall.ts
+++ b/src/models/Stall.ts
@@ -34,6 +34,7 @@ import HawkerCentre from './HawkerCentre';
 import Image from './Image';
 import Review from './Review';
 import Category from './Category';
+import { showCategoryStallFuncs } from '../controllers/categoryStallController';
 // import CategoryStall from './CategoryStall';
 
 export interface StallAttributes {
@@ -160,6 +161,14 @@ Stall.init(
         key: 'id',
       },
     },
+    nasty: {
+      type: DataTypes.VIRTUAL,
+      get() {
+        // this assumes that the call includes Categories
+        const categories: Category[] = this.getDataValue('Categories');
+        return categories.map(cate => cate.name);
+      },
+    },
   },
   { sequelize }
 );
@@ -174,5 +183,7 @@ Category.belongsToMany(Stall, { through: 'CategoryStalls', foreignKey: 'category
 
 Stall.hasMany(Review, { foreignKey: 'stallId' });
 Review.belongsTo(Stall, { foreignKey: 'stallId' });
+
+// Stall.addScope('asdf', { include: [{ association: Stall.associations.Categories }] });
 
 export default Stall;

--- a/src/models/Stall.ts
+++ b/src/models/Stall.ts
@@ -41,8 +41,9 @@ export interface StallAttributes {
   name: string;
   description: string | null;
   contactNo: string | null;
-  rating: number;
   unitNo: string | null;
+  rating: number;
+  // categories: string[];
   hawkerCentreId: number;
 }
 
@@ -54,8 +55,9 @@ class Stall extends Model<StallAttributes, StallCreationAttributes> implements S
   public description!: string | null;
   public contactNo!: string | null;
   public unitNo!: string | null;
-  public hawkerCentreId!: number;
   public rating!: number;
+  // public categories!: string[];
+  public hawkerCentreId!: number;
 
   public readonly createdAt!: Date;
   public readonly updatedAt!: Date;
@@ -152,20 +154,20 @@ Stall.init(
     rating: {
       type: DataTypes.VIRTUAL,
     },
+    // categories: {
+    //   type: DataTypes.VIRTUAL,
+    //   get() {
+    //     // this assumes that the call includes Categories
+    //     const categories = this.getDataValue('Categories') as Category[];
+    //     return categories.map(cate => cate.name);
+    //   },
+    // },
     hawkerCentreId: {
       type: DataTypes.INTEGER,
       allowNull: false,
       references: {
         model: 'HawkerCentres',
         key: 'id',
-      },
-    },
-    nasty: {
-      type: DataTypes.VIRTUAL,
-      get() {
-        // this assumes that the call includes Categories
-        const categories: Category[] = this.getDataValue('Categories');
-        return categories.map(cate => cate.name);
       },
     },
   },

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -75,7 +75,4 @@ User.init(
   { sequelize }
 );
 
-// User.hasMany(Review, { foreignKey: 'userId' });
-// Review.belongsTo(User, { foreignKey: 'userId' });
-
 export default User;

--- a/src/models/User.ts
+++ b/src/models/User.ts
@@ -75,7 +75,7 @@ User.init(
   { sequelize }
 );
 
-User.hasMany(Review, { foreignKey: 'userId' });
-Review.belongsTo(User, { foreignKey: 'userId' });
+// User.hasMany(Review, { foreignKey: 'userId' });
+// Review.belongsTo(User, { foreignKey: 'userId' });
 
 export default User;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,52 +1,57 @@
-import fs from 'fs';
-import path from 'path';
-import { Model } from 'sequelize/types';
+// import fs from 'fs';
+// import path from 'path';
+import { ModelStatic } from '../types';
+import { addScopes } from './init/addScopes';
 import { associate } from './init/associations';
 
-const basename = path.basename(__filename);
-const models: { [Key: string]: typeof Model } = {};
+// const basename = path.basename(__filename);
+// const models: { [Key: string]: typeof Model } = {};
 
-fs.readdirSync(__dirname)
-  .filter(file => {
-    // console.log(file);
-    return (
-      // exclude out build artifacts and init folder
-      file.indexOf('.') !== 0 &&
-      file !== basename &&
-      file !== 'init' &&
-      !file.endsWith('d.ts') &&
-      !file.endsWith('.map')
-    );
-  })
-  .forEach(file => {
-    const clazzName = file.substring(0, file.length - 3); // remove .ts or .js from the back
-    const model = require(path.join(__dirname, clazzName)); // this is the class
-    models[model.default.name] = model.default; // we export default from our models
-  });
+// fs.readdirSync(__dirname)
+//   .filter(file => {
+//     // console.log(file);
+//     return (
+//       // exclude out build artifacts and init folder
+//       file.indexOf('.') !== 0 &&
+//       file !== basename &&
+//       file !== 'init' &&
+//       !file.endsWith('d.ts') &&
+//       !file.endsWith('.map')
+//     );
+//   })
+//   .forEach(file => {
+//     const clazzName = file.substring(0, file.length - 3); // remove .ts or .js from the back
+//     const model = require(path.join(__dirname, clazzName)); // this is the class
+//     models[model.default.name] = model.default; // we export default from our models
+//   });
 
-// import Category from './Category';
-// import CategoryStall from './CategoryStall';
-// import HawkerCentre from './HawkerCentre';
-// import Image from './Image';
-// import Product from './Product';
-// import Region from './Region';
-// import Review from './Review';
-// import Stall from './Stall';
-// import User from './User';
+import Categoryzz from './Category';
+import CategoryStallzz from './CategoryStall';
+import HawkerCentrezz from './HawkerCentre';
+import Imagezz from './Image';
+import Productzz from './Product';
+import Regionzz from './Region';
+import Reviewzz from './Review';
+import Stallzz from './Stall';
+import Userzz from './User';
 
-// const models = {
-//   Category: Category,
-//   CategoryStall: CategoryStall,
-//   HawkerCentre: HawkerCentre,
-//   Image: Image,
-//   Product: Product,
-//   Region: Region,
-//   Review: Review,
-//   Stall: Stall,
-//   User: User,
-// };
+// This is done to typecheck correctly for files that import this file.
+const models = {
+  Category: Categoryzz,
+  CategoryStall: CategoryStallzz,
+  HawkerCentre: HawkerCentrezz,
+  Image: Imagezz,
+  Product: Productzz,
+  Region: Regionzz,
+  Review: Reviewzz,
+  Stall: Stallzz,
+  User: Userzz,
+};
 
-associate(models);
+type paramType = { [Key: string]: ModelStatic };
+
+associate(models as paramType);
+addScopes(models as paramType);
 
 // Need to do it this way, can't dynamically export from models
 const {

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -25,36 +25,40 @@ import { associate } from './init/associations';
 //     models[model.default.name] = model.default; // we export default from our models
 //   });
 
-import Categoryzz from './Category';
-import CategoryStallzz from './CategoryStall';
-import HawkerCentrezz from './HawkerCentre';
-import Imagezz from './Image';
-import Productzz from './Product';
-import Regionzz from './Region';
-import Reviewzz from './Review';
-import Stallzz from './Stall';
-import Userzz from './User';
+// import Categoryzz from './Category';
+// import CategoryStallzz from './CategoryStall';
+// import HawkerCentrezz from './HawkerCentre';
+// import Imagezz from './Image';
+// import Productzz from './Product';
+// import Regionzz from './Region';
+// import Reviewzz from './Review';
+// import Stallzz from './Stall';
+// import Userzz from './User';
+
+import Category from './Category';
+import CategoryStall from './CategoryStall';
+import HawkerCentre from './HawkerCentre';
+import Image from './Image';
+import Product from './Product';
+import Region from './Region';
+import Review from './Review';
+import Stall from './Stall';
+import User from './User';
+
 
 // This is done to typecheck correctly for files that import this file.
+// const models = {
+//   Category: Categoryzz,
+//   CategoryStall: CategoryStallzz,
+//   HawkerCentre: HawkerCentrezz,
+//   Image: Imagezz,
+//   Product: Productzz,
+//   Region: Regionzz,
+//   Review: Reviewzz,
+//   Stall: Stallzz,
+//   User: Userzz,
+// };
 const models = {
-  Category: Categoryzz,
-  CategoryStall: CategoryStallzz,
-  HawkerCentre: HawkerCentrezz,
-  Image: Imagezz,
-  Product: Productzz,
-  Region: Regionzz,
-  Review: Reviewzz,
-  Stall: Stallzz,
-  User: Userzz,
-};
-
-type paramType = { [Key: string]: ModelStatic };
-
-associate(models as paramType);
-addScopes(models as paramType);
-
-// Need to do it this way, can't dynamically export from models
-const {
   Category,
   CategoryStall,
   HawkerCentre,
@@ -64,7 +68,49 @@ const {
   Review,
   Stall,
   User,
-} = models;
+};
+
+type paramType = { [Key: string]: ModelStatic };
+
+associate(models as paramType);
+addScopes(models as paramType);
+
+// associate({
+//   Category,
+//   CategoryStall,
+//   HawkerCentre,
+//   Image,
+//   Product,
+//   Region,
+//   Review,
+//   Stall,
+//   User,
+// } as paramType);
+
+// addScopes({
+//   Category,
+//   CategoryStall,
+//   HawkerCentre,
+//   Image,
+//   Product,
+//   Region,
+//   Review,
+//   Stall,
+//   User,
+// } as paramType);
+
+// Need to do it this way, can't dynamically export from models
+// const {
+//   Category,
+//   CategoryStall,
+//   HawkerCentre,
+//   Image,
+//   Product,
+//   Region,
+//   Review,
+//   Stall,
+//   User,
+// } = models;
 
 export { Category, CategoryStall, HawkerCentre, Image, Product, Region, Review, Stall, User };
 

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,6 +1,6 @@
 // import fs from 'fs';
 // import path from 'path';
-import { ModelStatic } from '../types';
+import { Models, ModelStatic } from '../types';
 import { addScopes } from './init/addScopes';
 import { associate } from './init/associations';
 
@@ -70,10 +70,8 @@ const models = {
   User,
 };
 
-type paramType = { [Key: string]: ModelStatic };
-
-associate(models as paramType);
-addScopes(models as paramType);
+associate(models as Models);
+addScopes(models as Models);
 
 // associate({
 //   Category,

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,16 +1,19 @@
 import fs from 'fs';
 import path from 'path';
 import { Model } from 'sequelize/types';
+import { associate } from './init/associations';
 
 const basename = path.basename(__filename);
-const models: { [Key: string]: Model } = {};
+const models: { [Key: string]: typeof Model } = {};
 
 fs.readdirSync(__dirname)
   .filter(file => {
+    // console.log(file);
     return (
-      // exclude out build artifacts
+      // exclude out build artifacts and init folder
       file.indexOf('.') !== 0 &&
       file !== basename &&
+      file !== 'init' &&
       !file.endsWith('d.ts') &&
       !file.endsWith('.map')
     );
@@ -20,5 +23,44 @@ fs.readdirSync(__dirname)
     const model = require(path.join(__dirname, clazzName)); // this is the class
     models[model.default.name] = model.default; // we export default from our models
   });
+
+// import Category from './Category';
+// import CategoryStall from './CategoryStall';
+// import HawkerCentre from './HawkerCentre';
+// import Image from './Image';
+// import Product from './Product';
+// import Region from './Region';
+// import Review from './Review';
+// import Stall from './Stall';
+// import User from './User';
+
+// const models = {
+//   Category: Category,
+//   CategoryStall: CategoryStall,
+//   HawkerCentre: HawkerCentre,
+//   Image: Image,
+//   Product: Product,
+//   Region: Region,
+//   Review: Review,
+//   Stall: Stall,
+//   User: User,
+// };
+
+associate(models);
+
+// Need to do it this way, can't dynamically export from models
+const {
+  Category,
+  CategoryStall,
+  HawkerCentre,
+  Image,
+  Product,
+  Region,
+  Review,
+  Stall,
+  User,
+} = models;
+
+export { Category, CategoryStall, HawkerCentre, Image, Product, Region, Review, Stall, User };
 
 export default models;

--- a/src/models/index.ts
+++ b/src/models/index.ts
@@ -1,115 +1,42 @@
-// import fs from 'fs';
-// import path from 'path';
-import { Models, ModelStatic } from '../types';
+import fs from 'fs';
+import path from 'path';
+import { Models } from '../types';
 import { addScopes } from './init/addScopes';
 import { associate } from './init/associations';
 
-// const basename = path.basename(__filename);
-// const models: { [Key: string]: typeof Model } = {};
+const basename = path.basename(__filename);
+const models: Models = {};
 
-// fs.readdirSync(__dirname)
-//   .filter(file => {
-//     // console.log(file);
-//     return (
-//       // exclude out build artifacts and init folder
-//       file.indexOf('.') !== 0 &&
-//       file !== basename &&
-//       file !== 'init' &&
-//       !file.endsWith('d.ts') &&
-//       !file.endsWith('.map')
-//     );
-//   })
-//   .forEach(file => {
-//     const clazzName = file.substring(0, file.length - 3); // remove .ts or .js from the back
-//     const model = require(path.join(__dirname, clazzName)); // this is the class
-//     models[model.default.name] = model.default; // we export default from our models
-//   });
+fs.readdirSync(__dirname)
+  .filter(file => {
+    return (
+      // exclude out build artifacts and init folder
+      file.indexOf('.') !== 0 &&
+      file !== basename &&
+      file !== 'init' &&
+      !file.endsWith('d.ts') &&
+      !file.endsWith('.map')
+    );
+  })
+  .forEach(file => {
+    const clazzName = file.substring(0, file.length - 3); // remove .ts or .js from the back
+    const model = require(path.join(__dirname, clazzName)); // this is the class
+    models[model.default.name] = model.default; // we export default from our models
+  });
 
-// import Categoryzz from './Category';
-// import CategoryStallzz from './CategoryStall';
-// import HawkerCentrezz from './HawkerCentre';
-// import Imagezz from './Image';
-// import Productzz from './Product';
-// import Regionzz from './Region';
-// import Reviewzz from './Review';
-// import Stallzz from './Stall';
-// import Userzz from './User';
+// For some reason, when we pass the class itself, the modifications (e.g. associations and scoping) to the class is retained.
+// There is a good chance the class is already in the "global" scope.
+associate(models);
+addScopes(models);
 
-import Category from './Category';
-import CategoryStall from './CategoryStall';
-import HawkerCentre from './HawkerCentre';
-import Image from './Image';
-import Product from './Product';
-import Region from './Region';
-import Review from './Review';
-import Stall from './Stall';
-import User from './User';
-
-
-// This is done to typecheck correctly for files that import this file.
-// const models = {
-//   Category: Categoryzz,
-//   CategoryStall: CategoryStallzz,
-//   HawkerCentre: HawkerCentrezz,
-//   Image: Imagezz,
-//   Product: Productzz,
-//   Region: Regionzz,
-//   Review: Reviewzz,
-//   Stall: Stallzz,
-//   User: Userzz,
-// };
-const models = {
-  Category,
-  CategoryStall,
-  HawkerCentre,
-  Image,
-  Product,
-  Region,
-  Review,
-  Stall,
-  User,
-};
-
-associate(models as Models);
-addScopes(models as Models);
-
-// associate({
-//   Category,
-//   CategoryStall,
-//   HawkerCentre,
-//   Image,
-//   Product,
-//   Region,
-//   Review,
-//   Stall,
-//   User,
-// } as paramType);
-
-// addScopes({
-//   Category,
-//   CategoryStall,
-//   HawkerCentre,
-//   Image,
-//   Product,
-//   Region,
-//   Review,
-//   Stall,
-//   User,
-// } as paramType);
-
-// Need to do it this way, can't dynamically export from models
-// const {
-//   Category,
-//   CategoryStall,
-//   HawkerCentre,
-//   Image,
-//   Product,
-//   Region,
-//   Review,
-//   Stall,
-//   User,
-// } = models;
-
-export { Category, CategoryStall, HawkerCentre, Image, Product, Region, Review, Stall, User };
+export { default as Category } from './Category';
+export { default as CategoryStall } from './CategoryStall';
+export { default as HawkerCentre } from './HawkerCentre';
+export { default as Image } from './Image';
+export { default as Product } from './Product';
+export { default as Region } from './Region';
+export { default as Review } from './Review';
+export { default as Stall } from './Stall';
+export { default as User } from './User';
 
 export default models;

--- a/src/models/init/addScopes.ts
+++ b/src/models/init/addScopes.ts
@@ -1,0 +1,7 @@
+import { ModelStatic } from '../../types';
+
+export function addScopes(models: { [Key: string]: ModelStatic }) {
+  const { Stall } = models;
+
+  Stall.addScope('defaultScope', { include: [{ association: Stall.associations.Categories }] });
+}

--- a/src/models/init/addScopes.ts
+++ b/src/models/init/addScopes.ts
@@ -1,7 +1,7 @@
-import { ModelStatic } from '../../types';
+import { Models } from '../../types/';
 
-export function addScopes(models: { [Key: string]: ModelStatic }) {
-  const { Stall } = models;
-
-  Stall.addScope('defaultScope', { include: [{ association: Stall.associations.Categories }] });
+export function addScopes(_models: Models) {
+  // An example of using scope
+  // const { Stall } = models;
+  // Stall.addScope('defaultScope', { include: [{ association: Stall.associations.Categories }] });
 }

--- a/src/models/init/associations.ts
+++ b/src/models/init/associations.ts
@@ -1,0 +1,63 @@
+// import Category from '../Category';
+// import CategoryStall from '../CategoryStall';
+// import HawkerCentre from '../HawkerCentre';
+// import Image from '../Image';
+// import Product from '../Product';
+// import Region from '../Region';
+// import Review from '../Review';
+// import Stall from '../Stall';
+// import User form '../User';
+
+// import {
+//   Category,
+//   CategoryStall,
+//   HawkerCentre,
+//   Image,
+//   Product,
+//   Region,
+//   Review,
+//   Stall,
+//   User,
+// } from '../index';
+
+import { Model } from 'sequelize/types';
+
+export function associate(models: { [Key: string]: typeof Model }) {
+  const {
+    Category,
+    CategoryStall,
+    HawkerCentre,
+    Image,
+    Product,
+    Region,
+    Review,
+    Stall,
+    User,
+  } = models;
+
+  Stall.hasMany(Product, { foreignKey: 'stallId', onDelete: 'cascade', hooks: true });
+  Product.belongsTo(Stall, { foreignKey: 'stallId' });
+
+  Stall.hasMany(Image, { foreignKey: 'stallId' });
+
+  Stall.belongsToMany(Category, { through: 'CategoryStalls', foreignKey: 'stallId' });
+  Category.belongsToMany(Stall, { through: 'CategoryStalls', foreignKey: 'categoryId' });
+
+  Stall.hasMany(Review, { foreignKey: 'stallId' });
+  Review.belongsTo(Stall, { foreignKey: 'stallId' });
+
+  Stall.addScope('asdf', { include: [{ association: Stall.associations.Categories }] });
+}
+
+// Stall.hasMany(Product, { foreignKey: 'stallId', onDelete: 'cascade', hooks: true });
+// Product.belongsTo(Stall, { foreignKey: 'stallId' });
+
+// Stall.hasMany(Image, { foreignKey: 'stallId' });
+
+// Stall.belongsToMany(Category, { through: 'CategoryStalls', foreignKey: 'stallId' });
+// Category.belongsToMany(Stall, { through: 'CategoryStalls', foreignKey: 'categoryId' });
+
+// Stall.hasMany(Review, { foreignKey: 'stallId' });
+// Review.belongsTo(Stall, { foreignKey: 'stallId' });
+
+// Stall.addScope('asdf', { include: [{ association: Stall.associations.Categories }] });

--- a/src/models/init/associations.ts
+++ b/src/models/init/associations.ts
@@ -1,30 +1,4 @@
-// import Category from '../Category';
-// import CategoryStall from '../CategoryStall';
-// import HawkerCentre from '../HawkerCentre';
-// import Image from '../Image';
-// import Product from '../Product';
-// import Region from '../Region';
-// import Review from '../Review';
-// import Stall from '../Stall';
-// import User form '../User';
-
-// import {
-//   Category,
-//   CategoryStall,
-//   HawkerCentre,
-//   Image,
-//   Product,
-//   Region,
-//   Review,
-//   Stall,
-//   User,
-// } from '../index';
-
 import { Models } from '../../types/';
-
-// type ModelStatic = typeof Model & {
-//   new (values?: object, options?: Sequelize.BuildOptions): Model;
-// };
 
 export function associate(models: Models) {
   const { Category, HawkerCentre, Image, Product, Region, Review, Stall, User } = models;
@@ -50,16 +24,3 @@ export function associate(models: Models) {
 
   User.hasMany(Review, { foreignKey: 'userId' });
 }
-
-// Stall.hasMany(Product, { foreignKey: 'stallId', onDelete: 'cascade', hooks: true });
-// Product.belongsTo(Stall, { foreignKey: 'stallId' });
-
-// Stall.hasMany(Image, { foreignKey: 'stallId' });
-
-// Stall.belongsToMany(Category, { through: 'CategoryStalls', foreignKey: 'stallId' });
-// Category.belongsToMany(Stall, { through: 'CategoryStalls', foreignKey: 'categoryId' });
-
-// Stall.hasMany(Review, { foreignKey: 'stallId' });
-// Review.belongsTo(Stall, { foreignKey: 'stallId' });
-
-// Stall.addScope('asdf', { include: [{ association: Stall.associations.Categories }] });

--- a/src/models/init/associations.ts
+++ b/src/models/init/associations.ts
@@ -20,13 +20,13 @@
 //   User,
 // } from '../index';
 
-import { ModelStatic } from '../../types/';
+import { Models } from '../../types/';
 
 // type ModelStatic = typeof Model & {
 //   new (values?: object, options?: Sequelize.BuildOptions): Model;
 // };
 
-export function associate(models: { [Key: string]: ModelStatic }) {
+export function associate(models: Models) {
   const { Category, HawkerCentre, Image, Product, Region, Review, Stall, User } = models;
 
   Category.belongsToMany(Stall, { through: 'CategoryStalls', foreignKey: 'categoryId' });

--- a/src/models/init/associations.ts
+++ b/src/models/init/associations.ts
@@ -20,33 +20,35 @@
 //   User,
 // } from '../index';
 
-import { Model } from 'sequelize/types';
+import { ModelStatic } from '../../types/';
 
-export function associate(models: { [Key: string]: typeof Model }) {
-  const {
-    Category,
-    CategoryStall,
-    HawkerCentre,
-    Image,
-    Product,
-    Region,
-    Review,
-    Stall,
-    User,
-  } = models;
+// type ModelStatic = typeof Model & {
+//   new (values?: object, options?: Sequelize.BuildOptions): Model;
+// };
 
-  Stall.hasMany(Product, { foreignKey: 'stallId', onDelete: 'cascade', hooks: true });
-  Product.belongsTo(Stall, { foreignKey: 'stallId' });
+export function associate(models: { [Key: string]: ModelStatic }) {
+  const { Category, HawkerCentre, Image, Product, Region, Review, Stall, User } = models;
 
-  Stall.hasMany(Image, { foreignKey: 'stallId' });
-
-  Stall.belongsToMany(Category, { through: 'CategoryStalls', foreignKey: 'stallId' });
   Category.belongsToMany(Stall, { through: 'CategoryStalls', foreignKey: 'categoryId' });
 
-  Stall.hasMany(Review, { foreignKey: 'stallId' });
-  Review.belongsTo(Stall, { foreignKey: 'stallId' });
+  HawkerCentre.belongsTo(Region, { foreignKey: 'regionId' });
+  HawkerCentre.hasMany(Stall, { foreignKey: 'hawkerCentreId' });
 
-  Stall.addScope('asdf', { include: [{ association: Stall.associations.Categories }] });
+  Product.belongsTo(Stall, { foreignKey: 'stallId' });
+  Product.hasMany(Image, { foreignKey: 'productId' });
+
+  Region.hasMany(HawkerCentre, { foreignKey: 'regionId' });
+
+  Review.belongsTo(Stall, { foreignKey: 'stallId' });
+  Review.belongsTo(User, { foreignKey: 'userId' });
+
+  Stall.belongsTo(HawkerCentre, { foreignKey: 'hawkerCentreId' });
+  Stall.belongsToMany(Category, { through: 'CategoryStalls', foreignKey: 'stallId' });
+  Stall.hasMany(Image, { foreignKey: 'stallId' });
+  Stall.hasMany(Product, { foreignKey: 'stallId', onDelete: 'cascade', hooks: true });
+  Stall.hasMany(Review, { foreignKey: 'stallId' });
+
+  User.hasMany(Review, { foreignKey: 'userId' });
 }
 
 // Stall.hasMany(Product, { foreignKey: 'stallId', onDelete: 'cascade', hooks: true });

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -3,3 +3,5 @@ import { Model, BuildOptions } from 'sequelize/types';
 export type ModelStatic = typeof Model & {
   new (values?: object, options?: BuildOptions): Model;
 };
+
+export type Models = { [key: string]: ModelStatic };

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,0 +1,5 @@
+import { Model, BuildOptions } from 'sequelize/types';
+
+export type ModelStatic = typeof Model & {
+  new (values?: object, options?: BuildOptions): Model;
+};

--- a/src/utils/dbUtil.ts
+++ b/src/utils/dbUtil.ts
@@ -1,4 +1,4 @@
-import { ModelStatic } from '../types';
+import { Models } from '../types';
 import sequelize from '../db';
 import models from '../models';
 
@@ -12,9 +12,10 @@ export async function testAuthenticate() {
 }
 
 export async function truncateClazzes() {
-  Object.keys(models).forEach(async key => {
-    // Cast to unknown then to StaticModel for tsc to work
-    await (models[key] as ModelStatic).truncate({
+  const modelszz = models as Models; // force typecast so can index into models using string
+
+  Object.keys(modelszz).forEach(async key => {
+    await modelszz[key].truncate({
       cascade: true,
       restartIdentity: true,
     });

--- a/src/utils/dbUtil.ts
+++ b/src/utils/dbUtil.ts
@@ -1,10 +1,6 @@
+import { ModelStatic } from '../types';
 import sequelize from '../db';
 import models from '../models';
-
-interface StaticModel {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  truncate(options: any): void;
-}
 
 export async function testAuthenticate() {
   try {
@@ -18,8 +14,7 @@ export async function testAuthenticate() {
 export async function truncateClazzes() {
   Object.keys(models).forEach(async key => {
     // Cast to unknown then to StaticModel for tsc to work
-    const clazz: unknown = models[key];
-    await (clazz as StaticModel).truncate({
+    await (models[key] as ModelStatic).truncate({
       cascade: true,
       restartIdentity: true,
     });

--- a/tests/controllers/stallController.test.ts
+++ b/tests/controllers/stallController.test.ts
@@ -1,5 +1,5 @@
 import request from 'supertest';
-import Stall from '../../src/models/Stall';
+import { Stall } from '../../src/models/';
 import HawkerCentreFact from '../factories/HawkerCentreFactory';
 import StallFact from '../factories/StallFactory';
 import app from '../../src/server';

--- a/tests/factories/CategoryFactory.ts
+++ b/tests/factories/CategoryFactory.ts
@@ -1,7 +1,7 @@
 import { IFactory, Factory } from 'rosie';
 import { lorem } from 'faker';
 import BaseFactory from './BaseFactory';
-import Category from '../../src/models/Category';
+import { Category } from '../../src/models/';
 
 class CategoryFactory extends BaseFactory<Category> {
   private static defaultFactory = new Factory().attr('name', () => lorem.word());

--- a/tests/factories/HawkerCentreFactory.ts
+++ b/tests/factories/HawkerCentreFactory.ts
@@ -2,7 +2,7 @@ import { IFactory, Factory } from 'rosie';
 import { lorem } from 'faker';
 import BaseFactory from './BaseFactory';
 import RegionFact from './RegionFactory';
-import HawkerCentre from '../../src/models/HawkerCentre';
+import { HawkerCentre } from '../../src/models';
 
 class HawkerCentreFactory extends BaseFactory<HawkerCentre> {
   private static defaultFactory = new Factory()

--- a/tests/factories/ImageFactory.ts
+++ b/tests/factories/ImageFactory.ts
@@ -1,7 +1,7 @@
 import { IFactory, Factory } from 'rosie';
 import { random } from 'faker';
 import BaseFactory from './BaseFactory';
-import Image from '../../src/models/Image';
+import { Image } from '../../src/models';
 
 class ImageFactory extends BaseFactory<Image> {
   private static defaultFactory = new Factory().attr('fileName', () => `${random.uuid()}.jpeg`);

--- a/tests/factories/RegionFactory.ts
+++ b/tests/factories/RegionFactory.ts
@@ -1,6 +1,6 @@
 import { IFactory, Factory } from 'rosie';
 import { lorem } from 'faker';
-import Region from '../../src/models/Region';
+import { Region } from '../../src/models';
 import BaseFactory from './BaseFactory';
 
 class RegionFactory extends BaseFactory<Region> {

--- a/tests/factories/ReviewFactory.ts
+++ b/tests/factories/ReviewFactory.ts
@@ -1,7 +1,7 @@
 import { IFactory, Factory } from 'rosie';
 import { random } from 'faker';
 import BaseFactory from './BaseFactory';
-import Review from '../../src/models/Review';
+import { Review } from '../../src/models';
 import UserFactory from './UserFactory';
 import StallFactory from './StallFactory';
 

--- a/tests/factories/StallFactory.ts
+++ b/tests/factories/StallFactory.ts
@@ -1,7 +1,7 @@
 import { IFactory, Factory } from 'rosie';
 import { lorem } from 'faker';
 import HawkerCentreFact from './HawkerCentreFactory';
-import Stall from '../../src/models/Stall';
+import { Stall } from '../../src/models';
 import BaseFactory from './BaseFactory';
 import CategoryFactory from './CategoryFactory';
 import ReviewFactory from './ReviewFactory';

--- a/tests/factories/UserFactory.ts
+++ b/tests/factories/UserFactory.ts
@@ -1,7 +1,7 @@
 import { IFactory, Factory } from 'rosie';
 import { internet } from 'faker';
 import BaseFactory from './BaseFactory';
-import User from '../../src/models/User';
+import { User } from '../../src/models';
 
 class UserFactory extends BaseFactory<User> {
   private static defaultFactory = new Factory()


### PR DESCRIPTION
- To import models, do `import { model_name } from '../models'`. This will ensure that the initialisation code is ran.
- Association and `addScope` methods are now run in a single file individually. Look at `./models/init` folder for more info.
- Standardise output for Stall, `stallController` will output different json depending on whether it is returning a single stall or multiple stalls
- `searchController` follows the same json format by reusing methods in `stallController`